### PR TITLE
Fixing "Pamięć" in Polish translation

### DIFF
--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -1053,7 +1053,7 @@
     <string name="device_status" msgid="607405385799807324">"Informacje o telefonie"</string>
     <string name="device_status_summary" product="tablet" msgid="3292717754497039686">"Stan baterii, sieci i inne informacje"</string>
     <string name="device_status_summary" product="default" msgid="2599162787451519618">"Numer telefonu, sygnał itd."</string>
-    <string name="storage_settings" msgid="4211799979832404953">"Pamięć"</string>
+    <string name="storage_settings" msgid="4211799979832404953">"Pamięć telefonu"</string>
     <string name="storage_usb_settings" msgid="7293054033137078060">"Pamięć"</string>
     <string name="storage_settings_title" msgid="8746016738388094064">"Ustawienia pamięci"</string>
     <string name="storage_settings_summary" product="nosdcard" msgid="3543813623294870759">"Odłącz nośnik USB i wyświetl ilość dostępnej pamięci"</string>
@@ -2943,7 +2943,7 @@
     <string name="permit_usage_access" msgid="4012876269445832300">"Zezwól na dostęp do użytkowania"</string>
     <string name="app_usage_preference" msgid="7065701732733134991">"Ustawienia użycia aplikacji"</string>
     <string name="usage_access_description" msgid="1352111094596416795">"Dostęp do użytkowania umożliwia aplikacji śledzenie tego, jakich innych aplikacji i jak często używasz, oraz odczytywanie m.in. informacji o operatorze i ustawień językowych."</string>
-    <string name="memory_settings_title" msgid="7490541005204254222">"Pamięć"</string>
+    <string name="memory_settings_title" msgid="7490541005204254222">"Pamięć RAM"</string>
     <string name="memory_details_title" msgid="8542565326053693320">"Informacje dotyczące pamięci"</string>
     <string name="always_running" msgid="6042448320077429656">"Zawsze aktywna (<xliff:g id="PERCENTAGE">%s</xliff:g>)"</string>
     <string name="sometimes_running" msgid="6611250683037700864">"Czasami aktywna (<xliff:g id="PERCENTAGE">%s</xliff:g>)"</string>


### PR DESCRIPTION
Was quite annoying to find two "Pamiec" instead of one dedicated for Storage (Pamiec telefonu), and other one Memory (Pamiec RAM)