### PR TITLE
Allow virtually any password length

### DIFF
--- a/src/com/android/settings/password/ChooseLockPassword.java
+++ b/src/com/android/settings/password/ChooseLockPassword.java
@@ -192,7 +192,7 @@ public class ChooseLockPassword extends SettingsActivity {
         private ImeAwareEditText mPasswordEntry;
         private TextViewInputDisabler mPasswordEntryInputDisabler;
         private int mPasswordMinLength = LockPatternUtils.MIN_LOCK_PASSWORD_SIZE;
-        private int mPasswordMaxLength = 16;
+        private int mPasswordMaxLength = 160;
         private int mPasswordMinLetters = 0;
         private int mPasswordMinUpperCase = 0;
         private int mPasswordMinLowerCase = 0;


### PR DESCRIPTION
The default maximum password length in AOSP is pretty low with only 16 characters. Many people complain about this. There is no downside in increasing it: People who don't want a long password can still use a short one. So I propose increasing it to 160 characters for now! I think this change is all that is needed to do so, but have not compiled and tested with this change.